### PR TITLE
Support both Vim8 and NeoVim, using Async.vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,25 @@ Vim plugin that integrates [elixir-ls](https://github.com/JakeBecker/elixir-ls) 
 Use your favorite plugin manager. I prefer [vim-plug](https://github.com/junegunn/vim-plug):
 
 ```
-Plug 'GrzegorzKozub/vim-elixirls', { 'do': ':ElixirLsCompileSync' }
+Plug 'prabirshrestha/async.vim'
+Plug 'Kuret/vim-elixirls', { 'do': ':ElixirLsCompileSync' }
 ```
 
-Note that we're using [post-update hooks](https://github.com/junegunn/vim-plug#post-update-hooks) to automatically compile [elixir-ls](https://github.com/JakeBecker/elixir-ls) after this plugin has been installed or updated. 
+Note that we're using [post-update hooks](https://github.com/junegunn/vim-plug#post-update-hooks) to automatically compile [elixir-ls](https://github.com/JakeBecker/elixir-ls) after this plugin has been installed or updated.
 
 # How to integrate with ALE
 
 At the minimum, you will need to tell [ALE](https://github.com/w0rp/ale) where the compiled [elixir-ls](https://github.com/JakeBecker/elixir-ls) sits and enable it as linter:
 
 ```
+" Vim
 let s:user_dir = has('win32') ? expand('~/vimfiles/') : expand('~/.vim/')
-let g:ale_elixir_elixir_ls_release = s:user_dir . 'plugins/vim-elixirls/elixir-ls/release'
+
+" NeoVim
+let s:user_dir = has('win32') ? expand('~/AppData/Local/nvim') : expand('~/.config/nvim')
+
+" Location of your elixir-ls release, for vim-plug the plugins directory is usually 'plugged'
+let g:ale_elixir_elixir_ls_release = s:user_dir . 'plugged/vim-elixirls/elixir-ls/release'
 
 " https://github.com/JakeBecker/elixir-ls/issues/54
 let g:ale_elixir_elixir_ls_config = { 'elixirLS': { 'dialyzerEnabled': v:false } }
@@ -35,7 +42,7 @@ nnoremap <C-\> :ALEFindReferences<CR>
 nnoremap <Leader>d :ALEHover<CR>
 ```
 
-I'm using `mix format` to format my [elixir](https://elixir-lang.org/) code with this config: 
+I'm using `mix format` to format my [elixir](https://elixir-lang.org/) code with this config:
 
 ```
 let g:ale_fixers = {}
@@ -55,4 +62,3 @@ For [elixir-ls](https://github.com/JakeBecker/elixir-ls) to work, it needs to be
 ```
 :ElixirLsCompile
 ```
-

--- a/autoload/elixirls.vim
+++ b/autoload/elixirls.vim
@@ -1,5 +1,10 @@
 if exists('g:vim_elixirls_loaded') | finish | endif
 
+if !(&rtp =~ 'async.vim')
+  echoerr 'The vim-elixirls plugin requires Neovim or Vim 8 with the async.vim plugin'
+  finish
+endif
+
 let s:repo = expand('<sfile>:p:h:h') . '/elixir-ls'
 if exists('s:job_id') | unlet s:job_id | endif
 

--- a/autoload/elixirls.vim
+++ b/autoload/elixirls.vim
@@ -1,10 +1,5 @@
 if exists('g:vim_elixirls_loaded') | finish | endif
 
-if !exists('*job_start')
-  echoerr 'The vim-elixirls plugin requires Vim 8 with job_start()'
-  finish
-endif
-
 let s:repo = expand('<sfile>:p:h:h') . '/elixir-ls'
 if exists('s:job_id') | unlet s:job_id | endif
 
@@ -13,21 +8,57 @@ function! elixirls#compile(wait) abort
     echomsg 'ElixirLS is already currently compiling in the background'
     return
   endif
-  let l:script = 'mix deps.get && mix compile && mix elixir_ls.release -o release'
+
+  let l:script = 'cd ' . s:repo . ' && mix deps.get && mix compile && mix elixir_ls.release -o release'
   let l:command = has('win32') ? 'cmd /c ' . l:script : ['/bin/sh', '-c', l:script]
-  let s:job_id = job_start(l:command, { 'cwd': s:repo, 'exit_cb': function('s:exit_cb') })
-  if job_status(s:job_id) ==# 'run'
+  let s:job_id = async#job#start(l:command, {
+      \ 'on_stdout': function('s:handle_out'),
+      \ 'on_stderr': function('s:handle_error'),
+      \ 'on_exit': function('s:handle_exit'),
+  \ })
+
+  if s:job_id > 0
     echomsg 'ElixirLS compilation started'
-    while a:wait && exists('s:job_id') && job_status(s:job_id) ==# 'run' | sleep 1000m | endwhile
+    if a:wait
+      " Wait for job to finish with a 5 minute timeout
+      call async#job#wait([s:job_id], 300000)
+    endif
   else
     echoerr 'ElixirLS compilation failed to start'
     unlet s:job_id
   endif
 endfunction
 
-function! s:exit_cb(job, exit_status) abort
+function! s:handle_out(job_id, data, event_type) dict abort
+  " stdout
+endfunction
+
+function! s:handle_error(job_id, data, event_type) dict abort
+	let index = 0
+	while index < len(a:data)
+	   let line = a:data[index]
+
+     " Filter out warnings from the stderr
+     if match(line, 'warning: ') == 0
+       " Next line is probably a filename, indented with '  ', since this belongs to the warning, skip this line
+       if match(a:data[index + 1], '  ') == 0
+         let index = index + 1
+       endif
+     elseif match(line, '^\s*$') == -1
+       " Echo the error if it is not a warning and not an empty line
+       echoerr 'Error: ' . line
+     endif
+
+     " Since we are potentially increasing the index by 2, check if we do not exceed the total length
+     if index < len(a:data)
+	     let index = index + 1
+     endif
+	endwhile
+endfunction
+
+function! s:handle_exit(job_id, exit_status, event_type) dict abort
   if a:exit_status == 0
-    echomsg 'ElixirLS compiled successfully'
+    echomsg 'ElixirLS finished compiling'
   else
     echoerr 'ElixirLS compilation failed (' . a:exit_status . ')'
   endif
@@ -35,4 +66,3 @@ function! s:exit_cb(job, exit_status) abort
 endfunction
 
 let g:vim_elixirls_loaded = 1
-


### PR DESCRIPTION
I noticed this is using Vim 8 specific async functions, so I modified this to use async.vim as a universal solution.

I wanted to log the errors, but I noticed a 'warning' is also printed on the stdout, so i'm attempting to filter this (and the line after which prints the `filename:line_number`).

Let me know if this is something you want to support or if I should just keep my own fork.