### PR TITLE
Adds the ability to use a custom version of elixir-ls

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ autocmd FileType elixir,eelixir nnoremap <C-]> :ALEGoToDefinition<CR>
 autocmd FileType elixir,eelixir nnoremap <C-\> :ALEFindReferences<CR>
 ```
 
+You can use a version of elixir-ls other than the one that comes with this
+plugin by setting `g:vim_elixir_ls_elixir_ls_dir` to the path to your elixir-ls
+repo. Make sure to also set `g:ale_elixir_elixir_ls_release` as mentioned
+above.
+
 I'm using `mix format` to format my [elixir](https://elixir-lang.org/) code with this config: 
 
 ```

--- a/autoload/elixirls.vim
+++ b/autoload/elixirls.vim
@@ -105,12 +105,20 @@ function! s:handle_exit(exit_code) abort
 endfunction
 
 function! s:get_command() abort
+  if exists('g:vim_elixir_ls_elixir_ls_dir')
+    let l:change_dir = 'cd ' . g:vim_elixir_ls_elixir_ls_dir
+  else
+    let l:change_dir = ''
+  endif
+
   let l:commands = [
+    \ l:change_dir,
     \ 'mix deps.get > mix-deps.log 2>&1',
     \ 'mix compile > mix-compile.log 2>&1',
     \ 'mix elixir_ls.release -o release > mix-release.log 2>&1',
     \ 'rm *.log'
   \ ]
+
   let l:script = join(commands, ' && ')
   return has('win32') ? 'cmd /c ' . l:script : [ '/bin/sh', '-c', l:script ]
 endfunction


### PR DESCRIPTION
Thought it would be useful to allow users to use their own version of elixir-ls. This could also remove the need for your plugin to be updated in order to pull in the latest version of elixir-ls.