### PR TITLE
Point to latest maintained elixir-ls fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "elixir-ls"]
 	path = elixir-ls
-	url = https://github.com/JakeBecker/elixir-ls.git
+	url = https://github.com/elixir-lsp/elixir-ls.git


### PR DESCRIPTION
The maintained fork of elixir-ls is now at https://github.com/elixir-lsp/elixir-ls